### PR TITLE
Changes for updated Open Api spec

### DIFF
--- a/__tests__/unit/media.test.js
+++ b/__tests__/unit/media.test.js
@@ -11,26 +11,26 @@ const request = supertest(app);
 
 
 describe('POST /media', function() {
-    it('should return error message with 412 status code when no file is uploaded with the request', async function() {
+    it('should return error message with 412 status code when either mediaId or reportId is missing', async function() {
         // creates fake media id similar to what would typically be passed
         const fakeMediaId = String(new ObjectId()); 
 
-        // mock request
-        const response = await request.post('/media').send({ reportId: undefined, mediaId: fakeMediaId });
+        // mock request without reportId or mediaFile attached should throw error about reportId first.
+        const response = await request.post(`/media?mediaId=${fakeMediaId}`);
 
         // test response message and status
-        expect(response.body.message).toStrictEqual('Request body must contain both of the following properties: mediaId, reportId');
+        expect(response.body.message).toStrictEqual('Query string parameters must contain both of the following properties: mediaId, reportId');
         expect(response.body.status).toBe(412);
     });
 
 
-    it('should return error message with 412 status code and message about file requirement', async function () {
+    it('should return error message with 412 status code when no file is uploaded with the request', async function () {
         // creates fake report and media ids similar to what would typically be passed
         const fakeMediaId = String(new ObjectId()); 
         const fakeReportId = String(new ObjectId());
 
-        // mock request
-        const response = await request.post('/media').send({ reportId: fakeReportId , mediaId: fakeMediaId });
+        // mock request without mediaFile attachment, but with reportId and mediaId, should throw error about missing file
+        const response = await request.post(`/media?reportId=${fakeReportId}&mediaId=${fakeMediaId}`);
 
         // test response message and status
         expect(response.body.message).toStrictEqual('No files recieved');

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -10,7 +10,7 @@ const ExpressError = require('../ExpressError');
 function validateMediaUpload(request, response, next) {
     try {
         // throws error if request is missing either its reportId or mediaId
-        if (!request.body.reportId || !request.body.mediaId) throw new ExpressError('Request body must contain both of the following properties: mediaId, reportId', 412);
+        if (!request.query.reportId || !request.query.mediaId) throw new ExpressError('Request body must contain both of the following properties: mediaId, reportId', 412);
 
         // throws error if no file was sent with request
         if (!request.files) throw new ExpressError('No files recieved', 412) // 412 status code === 'Precondition Not Met'

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -10,7 +10,7 @@ const ExpressError = require('../ExpressError');
 function validateMediaUpload(request, response, next) {
     try {
         // throws error if request is missing either its reportId or mediaId
-        if (!request.query.reportId || !request.query.mediaId) throw new ExpressError('Request body must contain both of the following properties: mediaId, reportId', 412);
+        if (!request.query.reportId || !request.query.mediaId) throw new ExpressError('Query string parameters must contain both of the following properties: mediaId, reportId', 412);
 
         // throws error if no file was sent with request
         if (!request.files) throw new ExpressError('No files recieved', 412) // 412 status code === 'Precondition Not Met'

--- a/routes/media.js
+++ b/routes/media.js
@@ -15,13 +15,13 @@ const router = express.Router();
  * 
  * - Calls express-fileupload middleware to parse the request header for content-types of `multipart/formData`
  * - If founds, recieved files are set on the `request.files` property
- * - Custom middleware `validateMediaUpload` is called to validate the file upload and that both `reportId` and `mediaId` were passed in `request.body`.
+ * - Custom middleware `validateMediaUpload` is called to validate the file upload and that both `reportId` and `mediaId` were passed in `request.query`.
  * 
  */
 router.post('/', validateMediaUpload, async function (request, response, next) {
     try {
         // destructure variables from request body
-        const { reportId, mediaId } = request.body;
+        const { reportId, mediaId } = request.query;
 
         // initializes an s3 client instance in the target region according to your baked-in credentials
         const bucketOperations = s3Bucket(region, bucketName); 


### PR DESCRIPTION
**Summary**
Changed `POST /media` endpoint, testing suite, and `validateMediaUpload` middleware to look for `reportId` and `mediaId` properties in query string parameters instead of the request body. The reason for this change was the clutter around passing two different content-types into the request body unnecessarily. It also leaves the door open to modify the request body content type in the future if need be to something like`octet-stream`.