### PR TITLE
changed json schema reqs for reports

### DIFF
--- a/schema/report.json
+++ b/schema/report.json
@@ -20,10 +20,9 @@
         "description",
         "location",
         "locationType",
-        "pollutionType",
-        "mediaIds",
-        "mediaUploadSuccesses",
-        "mediaUploadFailures"
+        "datetime",
+        "datetimeType",
+        "pollutionType"
     ],
     "properties": {
         "description": {


### PR DESCRIPTION
**Summary**
Updated `reports.json` JSON schema document to reflect changes in the minimum required information needed to make a request to the `POST /reports` endpoint.