### PR TITLE
Bulk changes and additions to reports

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,9 +4,15 @@ module.exports = function () {
     const NODE_ENV = process.env.NODE_ENV;
     const AWS_S3_REGION = (NODE_ENV === 'test') ? process.env.TEST_AWS_S3_REGION : process.env.AWS_S3_REGION;
     const AWS_S3_NAME = (NODE_ENV === 'test') ? process.env.TEST_AWS_S3_NAME : process.env.AWS_S3_NAME;
+
+    const DB_URI = (NODE_ENV === 'test') ? process.env.TEST_DB_URI : process.env.DB_URI;
+    const DB_NAME = (NODE_ENV === 'test') ? process.env.TEST_DB_NAME : process.env.DB_NAME;
+
     return {
         PORT: process.env.PORT || 4000,
         AWS_S3_REGION,
-        AWS_S3_NAME
+        AWS_S3_NAME,
+        DB_URI,
+        DB_NAME
     }
 }();

--- a/models/report.js
+++ b/models/report.js
@@ -1,0 +1,7 @@
+function report() {
+    return {
+        
+    }
+}
+
+module.exports = report;

--- a/models/report.js
+++ b/models/report.js
@@ -1,4 +1,6 @@
 const databaseOps = require('../services/databaseOps');
+const argsMatchOp = require('../services/argsMatchOp');
+
 const ExpressError = require('../ExpressError');
 
 class Report {
@@ -18,16 +20,27 @@ class Report {
      */
     static async read(operation, args) {
         try {
-            // check that `idArray` is an array
-            if (!Array.isArray(idArray)) throw new ExpressError('idArray parameter is required and must be an Array containing at least one element', 400);
-
-            // check that the array isn't empty
-            if (idArray.length < 1) throw new ExpressError('idArray cannot be an empty array', 400);
+            // throws error if operation and args are mismatched
+            argsMatchOp(operation, args);
 
             // attempt connection with database
             const dbOps = await databaseOps('reports');
 
-            const result = readMany ? await dbOps.getPage()
+            switch (operation) {
+                case 'search':
+                    // calls `dbOps.search(args.query)`
+                    return;
+                case 'fullPage': 
+                    // calls `dbOps.getPage(args.page, args.size)
+                    return;
+                case 'singleReport':
+                    // calls `dbOps.getResource(args.reportId)`
+                    return;
+                default:
+                    // default operation
+                    return;
+            }
+            
         } catch (err) {
             throw new ExpressError(err.message, err.status);
         }

--- a/models/report.js
+++ b/models/report.js
@@ -1,6 +1,19 @@
 function report() {
     return {
-        
+        async getManyReports(page, size) {
+            try {
+            } catch (err) {
+
+            }
+        },
+        async getOneReport(reportId) {
+            try {
+
+            } catch (err) {
+                
+            }
+        }
+
     }
 }
 

--- a/models/report.js
+++ b/models/report.js
@@ -1,20 +1,39 @@
-function report() {
-    return {
-        async getManyReports(page, size) {
-            try {
-            } catch (err) {
+const databaseOps = require('../services/databaseOps');
+const ExpressError = require('../ExpressError');
 
-            }
-        },
-        async getOneReport(reportId) {
-            try {
+class Report {
+    static async create() {}
 
-            } catch (err) {
-                
-            }
+    /**
+     * `Report.read` takes exactly two arguments. The first parameter
+     * is a string describing the type of read operation that the client
+     * wishes to execute. It must be either: `search`, `fullPage`, 
+     * or `singleReport`. The second parameter, `args`, is an object
+     * containing several possible key-value combinations depending on
+     * the specified operation type.
+
+     * 
+     * @param {String} operation
+     * @param {Object} args
+     */
+    static async read(operation, args) {
+        try {
+            // check that `idArray` is an array
+            if (!Array.isArray(idArray)) throw new ExpressError('idArray parameter is required and must be an Array containing at least one element', 400);
+
+            // check that the array isn't empty
+            if (idArray.length < 1) throw new ExpressError('idArray cannot be an empty array', 400);
+
+            // attempt connection with database
+            const dbOps = await databaseOps('reports');
+
+            const result = readMany ? await dbOps.getPage()
+        } catch (err) {
+            throw new ExpressError(err.message, err.status);
         }
-
     }
-}
+    static async update() {}
+    static async delete() {}
+};
 
-module.exports = report;
+module.exports = Report;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express-fileupload": "^1.2.1",
         "jest": "^26.6.3",
         "lodash": "^4.17.21",
+        "mongodb": "^3.6.4",
         "morgan": "^1.10.0",
         "supertest": "^6.1.3"
       },
@@ -5238,6 +5239,15 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -6297,6 +6307,14 @@
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
       "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
       "peer": true
+    },
+    "node_modules/denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -12339,6 +12357,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -13305,6 +13329,53 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.4.tgz",
+      "integrity": "sha512-Y+Ki9iXE9jI+n9bVtbTOOdK0B95d6wVGSucwtBkvQ+HIvVdTCfpVRp01FDC24uhC/Q2WXQ8Lpq3/zwtB5Op9Qw==",
+      "dependencies": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws4": {
+          "optional": true
+        },
+        "bson-ext": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "mongodb-extjson": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb/node_modules/bson": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/morgan": {
@@ -14336,8 +14407,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "peer": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/promise": {
       "version": "8.1.0",
@@ -14653,7 +14723,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14920,6 +14989,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dependencies": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/require_optional/node_modules/resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -15111,6 +15197,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/sax": {
@@ -15585,6 +15683,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -21492,6 +21599,15 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -22320,6 +22436,11 @@
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
       "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
       "peer": true
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -27033,6 +27154,12 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -27854,6 +27981,26 @@
         "minimist": "^1.2.5"
       }
     },
+    "mongodb": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.4.tgz",
+      "integrity": "sha512-Y+Ki9iXE9jI+n9bVtbTOOdK0B95d6wVGSucwtBkvQ+HIvVdTCfpVRp01FDC24uhC/Q2WXQ8Lpq3/zwtB5Op9Qw==",
+      "requires": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+        }
+      }
+    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -28643,8 +28790,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "peer": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise": {
       "version": "8.1.0",
@@ -28890,7 +29036,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "peer": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -29101,6 +29246,22 @@
         }
       }
     },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -29256,6 +29417,15 @@
             "remove-trailing-separator": "^1.0.1"
           }
         }
+      }
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "sax": {
@@ -29654,6 +29824,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "spdx-correct": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express-fileupload": "^1.2.1",
     "jest": "^26.6.3",
     "lodash": "^4.17.21",
+    "mongodb": "^3.6.4",
     "morgan": "^1.10.0",
     "supertest": "^6.1.3"
   },

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const Report = require('../models/Report');
 
 // router
 const router = express.Router();
@@ -6,9 +7,20 @@ const router = express.Router();
 router.post('/', async function(request, response, next) {
     try {
         // get values from request body
-        const { description, location, locationType, datetime, datetimeType, pollutionType, mediaIds, mediaUploadSuccesses, mediaUploadFailures } = request.body;
+        const { 
+            description, 
+            location, 
+            locationType, 
+            datetime, 
+            datetimeType, 
+            pollutionType, 
+            mediaIds, 
+            mediaUploadSuccesses, 
+            mediaUploadFailures 
+        } = request.body;
 
         // send information
+        const result = await Report.create(); // FINISH CODE
 
         // return 201
         return response.status(201);
@@ -20,15 +32,63 @@ router.post('/', async function(request, response, next) {
 
 router.get('/', async function(request, response, next) {
     try {
+        // Look for page and size in query string params (should have been validated/ stocked with defaults by middleware)
+        const { page, size } = request.query;
 
+        // sets the type of read operation
+        const operation = 'fullPage';
+
+        // sets the page and size values into
+        const args = { page, size };
+
+        // gets a full page of results from the server
+        const results = await Report.read(operation, args);
+
+        // return the array of report objects
+        return response.status(200).json(results)
     } catch (err) {
         return next(err);
     }
 });
 
-router.get('/:routerId', async function(request, response, next) {
-    try {
 
+router.get('/:reportId', async function(request, response, next) {
+    try {
+        // gets the target report from the url params
+        const { reportId } = request.params;
+
+        // sets the read operation type
+        const operation = 'singleReport';
+
+        // sets the args object
+        const args = { reportId };
+
+        // looks from result from the sever
+        const report = await Report.read(operation, args);
+
+        // returns the report
+        return response.status(200).json(report);
+    } catch (err) {
+        return next(err);
+    }
+});
+
+router.get('/search', async function(request, response, next) {
+    try {
+        // get search query from the string params
+        const { query } = request.query;
+
+        // sets operation type
+        const operation = 'search';
+
+        // sets args
+        const args = { query };
+
+        // retrieves search results from server
+        const results = await Report.read(operation, args);
+
+        // return the search results
+        return response.status(200).json(results);
     } catch (err) {
         return next(err);
     }

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -25,3 +25,11 @@ router.get('/', async function(request, response, next) {
         return next(err);
     }
 });
+
+router.get('/:routerId', async function(request, response, next) {
+    try {
+
+    } catch (err) {
+        return next(err);
+    }
+});

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -1,0 +1,20 @@
+const express = require('express');
+
+// router
+const router = express.Router();
+
+router.post('/', async function(request, response, next) {
+    try {
+        // get values from request body
+        const { description, location, locationType, datetime, datetimeType, pollutionType, mediaIds, mediaUploadSuccesses, mediaUploadFailures } = request.body;
+
+        // send information
+
+        // return 201
+        return response.status(201);
+
+    } catch(err) {
+        return next(err);
+    }
+});
+

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -18,3 +18,10 @@ router.post('/', async function(request, response, next) {
     }
 });
 
+router.get('/', async function(request, response, next) {
+    try {
+
+    } catch (err) {
+        return next(err);
+    }
+});

--- a/services/argsMatchOp.js
+++ b/services/argsMatchOp.js
@@ -1,0 +1,39 @@
+const ExpressError = require('../ExpressError');
+
+/**
+ * Checks that the `args` object contains
+ * properties corresponding to the correct
+ * operation type. If a match occurs, the 
+ * function returns true, otherwise an error 
+ * is thrown
+ * 
+ * @param {String} operation 
+ * @param {Object} args 
+ */
+function argsMatchOp(operation, args) {
+    switch (operation) {
+        // the search operation type must contain
+        case 'search':
+            if (args.query !== undefined && typeof args.query === 'string') {
+                return true
+            } else {
+                throw new ExpressError('args must contain a `query` key corresponding to a string value ', 500);
+            }
+        case 'fullPage':
+            if (args.page && args.size) {
+                return true;
+            } else {
+                throw new ExpressError('Both page and size must be specified in args object when passing fullPage as operation type.', 500);
+            }
+        case 'singleReport':
+            if (args.reportId) {
+                return true;
+            } else {
+                throw new ExpressError('A reportId must be specified in `args` object for operation type: singleReport', 500);
+            }
+        default:
+            throw new ExpressError('Incorrect operation type', 500);
+    }
+}
+
+module.exports = argsMatchOp;

--- a/services/connect.js
+++ b/services/connect.js
@@ -1,0 +1,31 @@
+/** Contains logic for creating instance of mongodb connection */
+const { MongoClient } = require('mongodb');
+const { DB_URI, DB_NAME } = require('../config');
+const ExpressError = require('../helpers/ExpressError');
+
+/** returns a database */
+const getConnection = async () => {
+  
+  
+  try {
+    //create a new database cluster client instance
+    const client = new MongoClient(DB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+    
+    //connect to database cluster
+    await client.connect();
+
+    //establish connection with specific database by name
+    const db = client.db(DB_NAME);
+
+    return [ db, client ];
+
+  } catch (err) {
+    //read msg to console
+    console.log(err);
+
+    //throw internal error
+    throw new ExpressError('There was an error connecting with the server', 500);
+  }
+}
+
+module.exports = getConnection;

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -45,11 +45,19 @@ async function databaseOps(collectionName) {
              */
             async getResource(resourceId) {
                 try {
-                    return collection.findOne({ _id: resourceId });
+                    const result = await collection.findOne({ _id: resourceId });
+                    return result;
                 } catch (err) {
                     throw new ExpressError(err.message, err.status || 500);
                 } finally {
                     await killSwitch();
+                }
+            },
+            async search(query) {
+                try {
+                    const results = await collection.find();
+                } catch (err) {
+                    throw new ExpressError(err.message, err.status || 500);
                 }
             }
         }

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -1,0 +1,61 @@
+const { mongoClientHandler } = require('./connect');
+const ExpressError = require('../ExpressError');
+
+async function databaseOps(collectionName) {
+    try {
+        // get helpful utility functions from our mongo client handler
+        const { getCollectionInstance, killSwitch, checkClientConnection } = await mongoClientHandler();
+
+        // stores a connection to a specified collection, from which database operations can be made
+        const collection = getCollectionInstance(collectionName);
+
+        return {
+            /**
+             * Returns an array of resources given
+             * a specified page index number and size of page.
+             * 
+             * *NOTE:* Page indices start at 1.
+             * 
+             * @param {Number} page page number
+             * @param {Number} size qty of resources per page
+             */
+            async getPage(page, size) {
+                try {
+                    // calculates the number of skips based on page number and size of page
+                    const skips = size * (page - 1)
+
+                    // stores a cursor containing a page of resource objects
+                    const cursor = collection.find().skip(skips).limit(size);
+
+                    // convert the cursor into an array
+                    const reportsArray = await cursor.toArray();
+
+                    return reportsArray;
+                } catch (err) {
+                    throw new ExpressError(err.message, err.status || 500);
+                } finally {
+                    await killSwitch();
+                }
+            },
+            /**
+             * Returns the resource belonging to
+             * specified `resourceId`
+             * 
+             * @param {String} resourceId
+             */
+            async getResource(resourceId) {
+                try {
+                    return collection.findOne({ _id: resourceId });
+                } catch (err) {
+                    throw new ExpressError(err.message, err.status || 500);
+                } finally {
+                    await killSwitch();
+                }
+            }
+        }
+    } catch (err) {
+        throw new ExpressError(err.message, err.status || 500);
+    }
+}
+
+module.exports = databaseOps;


### PR DESCRIPTION
**Summary**
Added a number of new files relating to report operations. This includes three new `GET` endpoints on the sub-root `/reports`. Changed `getConnection` helper function to something more robust. It is now called `mongoClientHandler` and it returns a number of functions that can be used to work directly with a collection, check the status of the connection, and even a function called `killSwitch` that ends the client connection to the database. Additionally, instead of managing all database operations for the reports collection out of a closure function called `reports`, this logic was split into two different files. First, `/models/report.js`, which contains a `Report` class containing four methods: `create`, `read`, `update`, `delete`. This is a standard pattern. But then I decided to create an additional class that contains a generalized piece of logic called `databaseOps.js`. This file contains another closure function, and it returns at least three different general database maniplution functions: `getPage`, `getResource`, and `search`. 