### PR TITLE
Function: modified databaseOps().getPage to accept updated params, added unit tests

### DIFF
--- a/__tests__/integration/datebaseOps.test.js
+++ b/__tests__/integration/datebaseOps.test.js
@@ -1,0 +1,9 @@
+const databaseOps = require('../../services/databaseOps');
+
+// describe('tests write operation functions returned by databaseOps', function() {});
+
+// describe('tests read operations function returned by databaseOps', function() {});
+
+// describe('tests update operations functions returned by databaseOps', function() {});
+
+// describe('tests delete operations functions returned by databaseOps', function() {});

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -102,6 +102,7 @@ describe('tests for databaseOps().getPage', function() {
             // test that the returned array is empty
             expect(results.message).toBe(0);
         } catch(err) {
+            console.log(err);
             expect(err.message).toStrictEqual('query and projection args must both be type Object.');
         }
     });

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -1,0 +1,49 @@
+process.env.NODE_ENV = "test"; // declare test env
+
+const { TEST_COLLECTION_NAME, DB_NAME, DB_URI } = require('../../config');
+const { MongoClient } = require('mongodb');
+
+beforeAll(async () => {
+    // create new MongoClient instance
+    const client = new MongoClient(DB_URI, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true
+    });
+
+    try {
+        // initiate live connection between client instance and specified database uri
+        await client.connect();
+
+        // get connection with target test database and collection
+        const database = client.db(DB_NAME);
+        const collection = database.collection(TEST_COLLECTION_NAME);
+
+        // defines some mock data including a name and a town
+        const people = [
+            { firstName: "Alyssa", hometown: "Upland" },
+            { firstName: "Abhi", hometown: "Singapore" },
+            { firstName: "Noah", hometown: "Columbus" },
+            { firstName: "Austin", hometown: "Columbus"},
+            { firstName: "Gio", hometown: "Orlando" },
+            { firstName: "Claire", hometown: "Columbus" },
+            { firstName: "Ceren", hometown: "Istanbul" }
+        ];
+
+        // insert the array of mock data
+        await collection.insert(people);
+
+    } catch(err) {
+        console.log(err);
+    } finally {
+        // close live connection between client and database
+        await client.close();
+    }
+});
+
+describe('tests for databaseOps().getPage', function() {
+    it('should return')
+})
+
+afterAll(async () => {
+    // handle database tear down
+})

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -95,15 +95,27 @@ describe('tests for databaseOps().getPage', function() {
             const pageSize = testData.length;
             const pageNumber = 1;
 
-            // get results 
-            const results = await getPage(query, projection, pageNumber, pageSize);
-            console.log(results);
-
-            // test that the returned array is empty
-            expect(results.message).toBe(0);
+            // call function, but don't store return value since error is expected
+            await getPage(query, projection, pageNumber, pageSize);
         } catch(err) {
-            console.log(err);
             expect(err.message).toStrictEqual('query and projection args must both be type Object.');
+        }
+    });
+
+    it('Throws error if pageNumber or pageSize are less than 1', async function() {
+        try {
+            // retrieve getPage function from object returned from databaseOps function closure
+            const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
+
+            // defines parameters
+            const query = new Object();
+            const projection = new Object();
+            const pageSize = testData.length;
+            const pageNumber = 0;
+
+            await getPage(query, projection, pageNumber, pageSize);
+        } catch(err) {
+            expect(err.message).toStrictEqual('indices for pageNumber and pageSize begin at 1; cannot be 0 or negative numbers');
         }
     });
 });

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -45,5 +45,27 @@ describe('tests for databaseOps().getPage', function() {
 })
 
 afterAll(async () => {
-    // handle database tear down
+    // create new MongoClient instance
+    const client = new MongoClient(DB_URI, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true
+    });
+
+    try {
+        // initiate live connection between client instance and specified database uri
+        await client.connect();
+
+        // get connection with target test database and collection
+        const database = client.db(DB_NAME);
+        const collection = database.collection(TEST_COLLECTION_NAME);
+
+        // delete all documents in the database
+        collection.deleteMany({});
+        
+    } catch (err) {
+        console.log(err);
+    } finally {
+        // close live connection with database
+        await client.close();
+    }
 })

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -2,6 +2,18 @@ process.env.NODE_ENV = "test"; // declare test env
 
 const { TEST_COLLECTION_NAME, DB_NAME, DB_URI } = require('../../config');
 const { MongoClient } = require('mongodb');
+const databaseOps = require('../../services/databaseOps');
+
+// define mock data for tests
+const testData = [
+            { firstName: "Alyssa", hometown: "Upland" },
+            { firstName: "Abhi", hometown: "Singapore" },
+            { firstName: "Noah", hometown: "Columbus" },
+            { firstName: "Austin", hometown: "Columbus"},
+            { firstName: "Gio", hometown: "Orlando" },
+            { firstName: "Claire", hometown: "Columbus" },
+            { firstName: "Ceren", hometown: "Istanbul" }
+];
 
 beforeAll(async () => {
     // create new MongoClient instance
@@ -18,19 +30,8 @@ beforeAll(async () => {
         const database = client.db(DB_NAME);
         const collection = database.collection(TEST_COLLECTION_NAME);
 
-        // defines some mock data including a name and a town
-        const people = [
-            { firstName: "Alyssa", hometown: "Upland" },
-            { firstName: "Abhi", hometown: "Singapore" },
-            { firstName: "Noah", hometown: "Columbus" },
-            { firstName: "Austin", hometown: "Columbus"},
-            { firstName: "Gio", hometown: "Orlando" },
-            { firstName: "Claire", hometown: "Columbus" },
-            { firstName: "Ceren", hometown: "Istanbul" }
-        ];
-
         // insert the array of mock data
-        await collection.insert(people);
+        await collection.insert(testData);
 
     } catch(err) {
         console.log(err);
@@ -40,8 +41,15 @@ beforeAll(async () => {
     }
 });
 
-describe('tests for databaseOps().getPage', function() {
-    it('should return')
+describe('tests for databaseOps().getPage', async function() {
+    // retrieve getPage function from object returned from databaseOps function closure
+    const { getPage } = await databaseOps(TEST_COLLECTION_NAME);
+
+    it('should successfully get a page of results', async function() {
+        const query = {};
+        const projection = {};
+        const pageSize = 
+    });
 })
 
 afterAll(async () => {

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -42,7 +42,7 @@ beforeAll(async () => {
 });
 
 describe('tests for databaseOps().getPage', function() {
-    it('should retrieve exactly as many results as are in the collection, and then an empty array ', async function() {
+    it('should retrieve exactly as many results as are in the collection', async function() {
         try {
             // retrieve getPage function from object returned from databaseOps function closure
             const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
@@ -63,7 +63,26 @@ describe('tests for databaseOps().getPage', function() {
         }
     });
 
-    it('Should retrieve ')
+    it('Should get empty array if page extends range of results', async function() {
+        try {
+            // retrieve getPage function from object returned from databaseOps function closure
+            const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
+
+            // defines parameters
+            const query = {};
+            const projection = {};
+            const pageSize = testData.length;
+            const pageNumber = 2;
+
+            // get results 
+            const results = await getPage(query, projection, pageNumber, pageSize);
+
+            // test that the returned array has as many items as the testData array
+            expect(results.length).toBe(0);
+        } catch(err) {
+            console.log(err);
+        }
+    })
 })
 
 afterAll(async () => {

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -48,8 +48,8 @@ describe('tests for databaseOps().getPage', function() {
             const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
 
             // defines parameters
-            const query = {};
-            const projection = {};
+            const query = new Object();
+            const projection = new Object;
             const pageSize = testData.length;
             const pageNumber = 1;
 
@@ -69,8 +69,8 @@ describe('tests for databaseOps().getPage', function() {
             const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
 
             // defines parameters
-            const query = {};
-            const projection = {};
+            const query = new Object;
+            const projection = new Object;
             const pageSize = testData.length;
             const pageNumber = 2;
 
@@ -82,8 +82,30 @@ describe('tests for databaseOps().getPage', function() {
         } catch(err) {
             console.log(err);
         }
-    })
-})
+    });
+
+    it('Throws error if non-object type arg is passed to query or projection parameter', async function() {
+        try {
+            // retrieve getPage function from object returned from databaseOps function closure
+            const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
+
+            // defines parameters
+            const query = new String('This is a string');
+            const projection = new Object();
+            const pageSize = testData.length;
+            const pageNumber = 1;
+
+            // get results 
+            const results = await getPage(query, projection, pageNumber, pageSize);
+            console.log(results);
+
+            // test that the returned array is empty
+            expect(results.message).toBe(0);
+        } catch(err) {
+            expect(err.message).toStrictEqual('query and projection args must both be type Object.');
+        }
+    });
+});
 
 afterAll(async () => {
     // create new MongoClient instance
@@ -109,4 +131,4 @@ afterAll(async () => {
         // close live connection with database
         await client.close();
     }
-})
+});

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -63,7 +63,7 @@ describe('tests for databaseOps().getPage', function() {
         }
     });
 
-    it('Should get empty array if page extends range of results', async function() {
+    it('Should get empty array if pageSize * pageNumber extends index range of results', async function() {
         try {
             // retrieve getPage function from object returned from databaseOps function closure
             const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
@@ -77,7 +77,7 @@ describe('tests for databaseOps().getPage', function() {
             // get results 
             const results = await getPage(query, projection, pageNumber, pageSize);
 
-            // test that the returned array has as many items as the testData array
+            // test that the returned array is empty
             expect(results.length).toBe(0);
         } catch(err) {
             console.log(err);

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -31,7 +31,7 @@ beforeAll(async () => {
         const collection = database.collection(TEST_COLLECTION_NAME);
 
         // insert the array of mock data
-        await collection.insert(testData);
+        await collection.insertMany(testData);
 
     } catch(err) {
         console.log(err);
@@ -41,15 +41,29 @@ beforeAll(async () => {
     }
 });
 
-describe('tests for databaseOps().getPage', async function() {
-    // retrieve getPage function from object returned from databaseOps function closure
-    const { getPage } = await databaseOps(TEST_COLLECTION_NAME);
+describe('tests for databaseOps().getPage', function() {
+    it('should retrieve exactly as many results as are in the collection, and then an empty array ', async function() {
+        try {
+            // retrieve getPage function from object returned from databaseOps function closure
+            const { getPage } = await databaseOps(TEST_COLLECTION_NAME);        
 
-    it('should successfully get a page of results', async function() {
-        const query = {};
-        const projection = {};
-        const pageSize = 
+            // defines parameters
+            const query = {};
+            const projection = {};
+            const pageSize = testData.length;
+            const pageNumber = 1;
+
+            // get results 
+            const results = await getPage(query, projection, pageNumber, pageSize);
+
+            // test that the returned array has as many items as the testData array
+            expect(results.length).toBe(testData.length);
+        } catch(err) {
+            console.log(err);
+        }
     });
+
+    it('Should retrieve ')
 })
 
 afterAll(async () => {
@@ -68,7 +82,7 @@ afterAll(async () => {
         const collection = database.collection(TEST_COLLECTION_NAME);
 
         // delete all documents in the database
-        collection.deleteMany({});
+        await collection.deleteMany({}); // this MUST have an await statement before, or client will attempt closure during deletion
         
     } catch (err) {
         console.log(err);

--- a/config.js
+++ b/config.js
@@ -7,12 +7,14 @@ module.exports = function () {
 
     const DB_URI = (NODE_ENV === 'test') ? process.env.TEST_DB_URI : process.env.DB_URI;
     const DB_NAME = (NODE_ENV === 'test') ? process.env.TEST_DB_NAME : process.env.DB_NAME;
+    const TEST_COLLECTION_NAME = process.env.TEST_COLLECTION_NAME;
 
     return {
         PORT: process.env.PORT || 4000,
         AWS_S3_REGION,
         AWS_S3_NAME,
         DB_URI,
-        DB_NAME
+        DB_NAME,
+        TEST_COLLECTION_NAME
     }
 }();

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -36,7 +36,7 @@ async function databaseOps(collectionName) {
              */
             async getPage(query, projection, pageNumber, pageSize) {
                 try {
-                    // input verification logic
+                    // TODO: add input verification logic -->
                     // should include a step that checks input types and required properties in
                     // query and projection
 

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -1,6 +1,14 @@
 const { mongoClientHandler } = require('./connect');
 const ExpressError = require('../ExpressError');
 
+
+/**
+ * Returns a collection of database operation functions 
+ * for the specified collection.
+ * 
+ * @param {String} collectionName 
+ * 
+ */
 async function databaseOps(collectionName) {
     try {
         // get helpful utility functions from our mongo client handler
@@ -24,8 +32,14 @@ async function databaseOps(collectionName) {
                     // calculates the number of skips based on page number and size of page
                     const skips = size * (page - 1)
 
+                    // insert an empty query object
+                    const query = {};
+
+                    // sorts by ascending timestamp
+                    const sort = { timestamp: 1 };
+
                     // stores a cursor containing a page of resource objects
-                    const cursor = collection.find().skip(skips).limit(size);
+                    const cursor = collection.find(query).sort(sort).skip(skips).limit(size);
 
                     // convert the cursor into an array
                     const reportsArray = await cursor.toArray();
@@ -55,11 +69,16 @@ async function databaseOps(collectionName) {
             },
             async search(query) {
                 try {
-                    const results = await collection.find();
+                    const results = collection.find(query);
+                    const array = await results.toArray();
+                    return array;
                 } catch (err) {
                     throw new ExpressError(err.message, err.status || 500);
                 }
-            }
+            },
+            async createNewResource() {},
+            
+
         }
     } catch (err) {
         throw new ExpressError(err.message, err.status || 500);

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -56,10 +56,10 @@ async function databaseOps(collectionName) {
                     const cursor = collection.find(query, options).skip(skips).limit(pageSize);
 
                     // convert the cursor into an array
-                    const reportsArray = await cursor.toArray();
+                    const resultsArray = await cursor.toArray();
 
                     // return results
-                    return reportsArray;
+                    return resultsArray;
                 } catch (err) {
                     throw new ExpressError(err.message, err.status || 500);
                 } finally {

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -37,6 +37,13 @@ async function databaseOps(collectionName) {
             async getPage(query, projection, pageNumber, pageSize) {
                 try {
                     // TODO: add input verification logic -->
+                    if (typeof query === 'object' && typeof projection === 'object') {
+                        throw new ExpressError('query and projection args must both be type Object.', 500);
+                    }
+
+                    if (typeof pageNumber === 'number' && typeof pageSize === 'number') {
+                        throw new ExpressError('pageNumber and pageSize args must both be type Number.', 500);
+                    }
                     // should include a step that checks input types and required properties in
                     // query and projection
 

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -36,21 +36,29 @@ async function databaseOps(collectionName) {
              */
             async getPage(query, projection, pageNumber, pageSize) {
                 try {
-                    // calculates the number of skips based on page number and size of page
-                    const skips = size * (page - 1)
+                    // input verification logic
+                    // should include a step that checks input types and required properties in
+                    // query and projection
 
-                    // insert an empty query object
-                    const query = {};
+                    // calculates the number of skips based on page number and size of page
+                    const skips = pageSize * (pageNumber - 1)
 
                     // sorts by ascending timestamp
                     const sort = { timestamp: 1 };
 
+                    // assemble an options object that includes the sort and projection preferences
+                    const options = {
+                        projection,
+                        sort
+                    };
+
                     // stores a cursor containing a page of resource objects
-                    const cursor = collection.find(query).sort(sort).skip(skips).limit(size);
+                    const cursor = collection.find(query, options).skip(skips).limit(pageSize);
 
                     // convert the cursor into an array
                     const reportsArray = await cursor.toArray();
 
+                    // return results
                     return reportsArray;
                 } catch (err) {
                     throw new ExpressError(err.message, err.status || 500);

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -19,15 +19,22 @@ async function databaseOps(collectionName) {
 
         return {
             /**
-             * Returns an array of resources given
-             * a specified page index number and size of page.
+             * Takes four parameters--`query <Object>`, `projection <Object>`, 
+             * `pageNumber <Number>`, `pageSize <Number>`--and returns an array of objects
+             * representing one page of results.
              * 
              * *NOTE:* Page indices start at 1.
              * 
-             * @param {Number} page page number
-             * @param {Number} size qty of resources per page
+             * @param {Object} query a query object as defined in MongoDB Node.js driver docs. It sets
+             * the search parameters for what kinds of resources should be returned by a database.
+             * 
+             * @param {Object} projection a projection object as defined in the MongoDB Node.js driver docs.
+             * It sets the output properties of the objects in the return array.
+             * 
+             * @param {Number} pageNumber sets the maximum number of results to be returned by the array.
+             * @param {Number} pageSize determines the number of results to skip before returning a results array.
              */
-            async getPage(page, size) {
+            async getPage(query, projection, pageNumber, pageSize) {
                 try {
                     // calculates the number of skips based on page number and size of page
                     const skips = size * (page - 1)

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -36,17 +36,22 @@ async function databaseOps(collectionName) {
              */
             async getPage(query, projection, pageNumber, pageSize) {
                 try {
-                    // TODO: add input verification logic -->
-                    if (typeof query === 'object' && typeof projection === 'object') {
+
+                    // throw error if query or projection are passed non-object args
+                    if (typeof query !== 'object' || typeof projection !== 'object') {
                         throw new ExpressError('query and projection args must both be type Object.', 500);
                     }
 
-                    if (typeof pageNumber === 'number' && typeof pageSize === 'number') {
+                    // throw error if pageNumber or pageSize are passed non-Number args
+                    if (typeof pageNumber !== 'number' || typeof pageSize !== 'number') {
                         throw new ExpressError('pageNumber and pageSize args must both be type Number.', 500);
                     }
-                    // should include a step that checks input types and required properties in
-                    // query and projection
 
+                    // throw error if pageNumber or pageSize are less than 1
+                    if (pageNumber < 1 || pageSize < 1) {
+                        throw new ExpressError('indices for pageNumber and pageSize begin at 1; cannot be 0 or negative numbers', 500);
+                    }
+                    
                     // calculates the number of skips based on page number and size of page
                     const skips = pageSize * (pageNumber - 1)
 


### PR DESCRIPTION
## Summary
Updated `getPage`, a function returned by `databaseOps` closure. 

## Description of Changes
The modifications were made in accordance with the spec changes outlined in issue #54, which directed that the function should take four parameters: `query`, `projection`, `pageNumber`, and `pageSize`. The previous function definition only took two parameters: `page`, and `size`. These changes required modifying the function's internal logic in minor ways. `query` and `projection` are objects defined by MongoDB, and thus were easily integrated into the `MongoClient.find` method. Lastly, some input checks were added to the function, including checks on input type as well as checks on value bounds.

## QA/Testing
Four unit tests were added to a new testing file: `~/__tests__/unit/databseOps.test.js`. The first two tested for normal inputs and expected outcomes, while three and four tested for proper error handling in the event of incorrect input types.