### PR TITLE
updated getResource function in databaseOps return object

### DIFF
--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -131,7 +131,7 @@ describe('tests for databaseOps().getPage', function() {
 
 describe('tests for databaseOps().getResource', function() {
     // test normal behavior
-    it('should get the correct item from database when given valid _id string', async function() {
+    it('should get the correct item from database when given valid id string', async function() {
         try {
             // get function to test
             const { getResource } = await databaseOps(TEST_COLLECTION_NAME);
@@ -171,7 +171,7 @@ describe('tests for databaseOps().getResource', function() {
         } catch (err) {
             error = err;
         } finally {
-            expect(error.message).toStrictEqual('Only one string arugment is allowed.', 500);
+            expect(error.message).toStrictEqual('Input must be a string', 500);
             expect(document).toBe(false); // document should still be false if error was thrown
         }
     });

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -120,6 +120,14 @@ describe('tests for databaseOps().getPage', function() {
     });
 });
 
+describe('tests for databaseOps().getResource', function() {
+    // test normal behavior
+
+    // test that error is thrown when incorrect paramter type is passed
+
+    // test the error is thrown when paramter type is correct, but no match is found in the database
+});
+
 afterAll(async () => {
     // create new MongoClient instance
     const client = new MongoClient(DB_URI, {

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -2,6 +2,7 @@ process.env.NODE_ENV = "test"; // declare test env
 
 const { TEST_COLLECTION_NAME, DB_NAME, DB_URI } = require('../../config');
 const { MongoClient } = require('mongodb');
+const { ObjectId } = require('bson');
 const databaseOps = require('../../services/databaseOps');
 
 // define mock data for tests
@@ -14,6 +15,14 @@ const testData = [
             { firstName: "Claire", hometown: "Columbus" },
             { firstName: "Ceren", hometown: "Istanbul" }
 ];
+
+// for each test data item, create a bson objectId and set into the data object
+// this will me it easier for us to test our query functions later on
+testData.forEach((v) => {
+    v._id = new ObjectId();
+});
+
+
 
 beforeAll(async () => {
     // create new MongoClient instance
@@ -122,6 +131,29 @@ describe('tests for databaseOps().getPage', function() {
 
 describe('tests for databaseOps().getResource', function() {
     // test normal behavior
+    it('should get the correct item from database when given valid _id string', async function() {
+        try {
+            // get function to test
+            const { getResource } = await databaseOps(TEST_COLLECTION_NAME);
+
+            // get first item in test data array
+            const testDataFirstItem = testData[0]
+
+            // get document from database
+            const document = await getResource(testDataFirstItem._id);
+
+            // test that the retreived item matches the mock data item inserted earlier:
+            // check against firstName prop
+            expect(document.firstName).toStrictEqual(testDataFirstItem.firstName);
+
+            // check against hometown prop
+            expect(document.hometown).toStrictEqual(testDataFirstItem.hometown);
+
+        } catch (err) {
+            console.log(err);
+        }
+    });
+
 
     // test that error is thrown when incorrect paramter type is passed
 

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -156,7 +156,25 @@ describe('tests for databaseOps().getResource', function() {
 
 
     // test that error is thrown when incorrect paramter type is passed
+    it('should throw an error when incorrect parameter type is passed', async function() {
+        let error = false;
+        let document = false;
+        try {
+            // get function to test
+            const { getResource } = await databaseOps(TEST_COLLECTION_NAME);
 
+            // incorrect input type
+            const numberInput = 5;
+
+            // get document from database
+            document = await getResource(numberInput);
+        } catch (err) {
+            error = err;
+        } finally {
+            expect(error.message).toStrictEqual('Only one string arugment is allowed.', 500);
+            expect(document).toBe(false);
+        }
+    });
     // test the error is thrown when paramter type is correct, but no match is found in the database
 });
 

--- a/__tests__/unit/databaseOps.test.js
+++ b/__tests__/unit/databaseOps.test.js
@@ -172,10 +172,33 @@ describe('tests for databaseOps().getResource', function() {
             error = err;
         } finally {
             expect(error.message).toStrictEqual('Only one string arugment is allowed.', 500);
+            expect(document).toBe(false); // document should still be false if error was thrown
+        }
+    });
+
+
+    // test the error is thrown when paramter type is correct, but no match is found in the database
+    it('should throw an error when input id does not match any documents in the database', async function() {
+        let error = false;
+        let document = false;
+        try {
+            // get function to test
+            const { getResource } = await databaseOps(TEST_COLLECTION_NAME);
+
+            // create fake id string
+            const fakeId = String(new ObjectId());
+
+            // execute function
+            document = await getResource(fakeId);
+
+        } catch(err) {
+            error = err;
+        } finally {
+            // test results
+            expect(error.message).toStrictEqual('No matching documents found');
             expect(document).toBe(false);
         }
     });
-    // test the error is thrown when paramter type is correct, but no match is found in the database
 });
 
 afterAll(async () => {

--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -1,5 +1,6 @@
 const { mongoClientHandler } = require('./connect');
 const ExpressError = require('../ExpressError');
+const { ObjectId } = require('bson');
 
 
 /**
@@ -79,14 +80,28 @@ async function databaseOps(collectionName) {
                 }
             },
             /**
-             * Returns the resource belonging to
-             * specified `resourceId`
+             * Takes an `id <String>` parameter as its only input 
+             * and returns the corresponding document (as an <Object>).
+             * The function throws an error if no matching document is
+             * found, or if the input id is not a string.
              * 
-             * @param {String} resourceId
+             * @param {String} id
              */
-            async getResource(resourceId) {
+            async getResource(id) {
                 try {
-                    const result = await collection.findOne({ _id: resourceId });
+                    // throws error if input is not a string
+                    if (typeof id !== 'string') throw new ExpressError('Input must be a string', 500);
+
+                    // pass id string to ObjectId constructor to create abstract type understood by MongoDB
+                    const _id = new ObjectId(id);
+
+                    // queries database for document with an id match input arg
+                    const result = await collection.findOne({ _id });
+
+                    // throw error if no document is returned from query
+                    if (!result) throw new ExpressError('No matching documents found', 500);
+
+                    // return result 
                     return result;
                 } catch (err) {
                     throw new ExpressError(err.message, err.status || 500);


### PR DESCRIPTION
**Summary**
Updated `getResource` function returned from `databaseOps` closure function to match specs described in issue #60.

**Description of Changes**
- Added three unit tests to check the function's normal behavior as well as basic edge cases where inputs have the incorrect type or return no matching documents.
- Updated `getResource` logic to include type checking the throw proper error messages.
- changed JSDoc description and updated name from `resourceId` to `id`.