### PR TITLE
deleted function "search" from dbOps return obj

### DIFF
--- a/services/databaseOps.js
+++ b/services/databaseOps.js
@@ -109,15 +109,6 @@ async function databaseOps(collectionName) {
                     await killSwitch();
                 }
             },
-            async search(query) {
-                try {
-                    const results = collection.find(query);
-                    const array = await results.toArray();
-                    return array;
-                } catch (err) {
-                    throw new ExpressError(err.message, err.status || 500);
-                }
-            },
             async setManyResources() {},
             async setResource() {},
             async deleteResource() {},


### PR DESCRIPTION
## Summary
Deleted `search` function from `databaseOps` function closure. Previously the read operation for multiple documents was going to be separated into `getPage` and `search` functions. Now, the functionality for open-ended search queries, as well as for standard page-resource fetching, has been collapsed into a single read operation: `getPages`.